### PR TITLE
Fixing incorrect encoding of an HTML entity within an HTML attribute.

### DIFF
--- a/roboto.html
+++ b/roboto.html
@@ -6,4 +6,4 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
The attribute is not escaping the & and thus generates a warning from validators about incorrect encoding of the entity.
