### PR TITLE
Update roboto.html so it uses Roboto

### DIFF
--- a/roboto.html
+++ b/roboto.html
@@ -6,4 +6,4 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Currently this file uses RobotoDraft, but it should probably use Roboto instead.
Note that https://www.polymer-project.org/0.5/docs/start/tutorial/step-1.html needs to be updated as well (still talks about RobotoDraft).