### PR TITLE
Add a crossorigin header to the font import.

### DIFF
--- a/roboto.html
+++ b/roboto.html
@@ -6,4 +6,4 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css' crossorigin='anonymous'>


### PR DESCRIPTION
Followup from our internal discussion. Add a crossorigin header to the font import. This lets JavaScript discover its contents. GStatic provides the necessary CORS header that allows it to work.
